### PR TITLE
Flutter stroke width

### DIFF
--- a/lib/app_utils.dart
+++ b/lib/app_utils.dart
@@ -17,6 +17,9 @@ const int remainingColorThreshhold = 50;
 const int maxNumOfCompMoves        = 10000;
 
 const double opacity       = 0.8;
+const double defaultwidth = 5.1257142857142854;
+const double mediumWidth = 8;
+const double thickWidth = 13;
 const double normForStrokeWidth = 0.0075;
 const double ticksPerCM = 2 * 100;
 const double maxRobotWidth               = 25   * ticksPerCM;
@@ -59,9 +62,9 @@ final Offset pinkOffset   = getColorOffset(1, 4);
 final Offset whiteOffset  = getColorOffset(1, 5);
 
 const Offset dummyOffset = Offset(-1, -1);
-final DrawingPoint upPoint    = DrawingPoint(location: dummyOffset, type: PointType.dummyUp, paint: Paint());
-final DrawingPoint downPoint  = DrawingPoint(location: dummyOffset, type: PointType.dummyDown, paint: Paint());
-final DrawingPoint startPoint = DrawingPoint(location: const Offset(0, maxRobotHight), type: PointType.regular, paint: Paint());
+final DrawingPoint upPoint    = DrawingPoint(location: dummyOffset, type: PointType.dummyUp, paint: Paint(), strokeWidth: defaultwidth);
+final DrawingPoint downPoint  = DrawingPoint(location: dummyOffset, type: PointType.dummyDown, paint: Paint(), strokeWidth: defaultwidth);
+final DrawingPoint startPoint = DrawingPoint(location: const Offset(0, maxRobotHight), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth);
 
 final DatabaseReference numOfMovesRef = FirebaseDatabase.instance.ref("NumOfMoves");
 final DatabaseReference movesRef      = FirebaseDatabase.instance.ref("RobotMoves");
@@ -80,7 +83,8 @@ class DrawingPoint {
   final PointType type;
   final Offset    location;
   final Paint     paint;
-  const DrawingPoint({required this.location, required this.type, required this.paint});
+  final double    strokeWidth;
+  const DrawingPoint({required this.location, required this.type, required this.paint, required this.strokeWidth});
   void printPoint() {
     debugPrint(location.dx.round().toString() + " " + location.dy.round().toString() + " " + type.toString());
   }

--- a/lib/bresenham_algo.dart
+++ b/lib/bresenham_algo.dart
@@ -110,8 +110,9 @@ List<DrawingPoint> globalBresenham(List<DrawingPoint> smoothPoints) {
     final int curY = smoothPoints[i].location.dy.round();
     final int nexX = smoothPoints[i + 1].location.dx.round();
     final int nexY = smoothPoints[i + 1].location.dy.round();
+    final double curWidth = smoothPoints[i].strokeWidth;
     if (curType == PointType.regular && nexType == PointType.regular) {
-      bresenhamPoints += localBresenham(curX, curY, nexX, nexY);
+      bresenhamPoints += localBresenham(curX, curY, nexX, nexY, curWidth);
     } else if (curType == PointType.regular && nexType != PointType.regular) {
       continue;
     } else if (curType == PointType.dummyUp) {
@@ -121,8 +122,8 @@ List<DrawingPoint> globalBresenham(List<DrawingPoint> smoothPoints) {
       final int beforeUpY = smoothPoints[i - 2].location.dy.round();
       final int afterLogisticX = smoothPoints[i + 2].location.dx.round();
       final int afterLogisticY = smoothPoints[i + 2].location.dy.round();
-      bresenhamPoints += localBresenham(beforeUpX, beforeUpY, nexX, nexY);
-      bresenhamPoints += localBresenham(nexX, nexY, afterLogisticX, afterLogisticY);
+      bresenhamPoints += localBresenham(beforeUpX, beforeUpY, nexX, nexY, curWidth);
+      bresenhamPoints += localBresenham(nexX, nexY, afterLogisticX, afterLogisticY, curWidth);
       bresenhamPoints.add(downPoint);
       i++;
     }
@@ -130,7 +131,7 @@ List<DrawingPoint> globalBresenham(List<DrawingPoint> smoothPoints) {
   return bresenhamPoints;
 }
 
-List<DrawingPoint> localBresenham(int x0, int y0, int x1, int y1) {
+List<DrawingPoint> localBresenham(int x0, int y0, int x1, int y1, double width) {
   List<DrawingPoint> bresenhamPoints = [];
   var dx = (x1 - x0).abs();
   var dy = (y1 - y0).abs();
@@ -138,7 +139,10 @@ List<DrawingPoint> localBresenham(int x0, int y0, int x1, int y1) {
   var sy = (y0 < y1) ? 1 : -1;
   var err = dx - dy;
   while (true) {
-    bresenhamPoints.add(DrawingPoint(location: Offset(x0.toDouble(), y0.toDouble()), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+    bresenhamPoints.add(DrawingPoint(location: Offset(x0.toDouble(),y0.toDouble()),
+                                     type: PointType.regular,
+                                     paint: Paint(),
+                                     strokeWidth: width));
     if ((x0 == x1) && (y0 == y1)) {
       break;
     }
@@ -165,7 +169,15 @@ List<RobotMove> getRobotMoves(List<DrawingPoint> bresenhamPoints) {
       continue;
     }
     if (cur.type == PointType.dummyDown) {
-      robotMoves.add(RobotMove.servoDown);
+      if (nex.strokeWidth == defaultwidth) {
+        robotMoves.add(RobotMove.servoDown);
+      } else if (nex.strokeWidth == mediumWidth) {
+        robotMoves.add(RobotMove.servoDown);
+      } else if (nex.strokeWidth == thickWidth) {
+        robotMoves.add(RobotMove.servoDown);
+      } else {
+        assert (false);
+      }
       continue;
     }
     if (cur.type == PointType.dummyUp) {

--- a/lib/bresenham_algo.dart
+++ b/lib/bresenham_algo.dart
@@ -21,7 +21,7 @@ List<DrawingPoint> getScaledPoints(List<DrawingPoint> points, double width, doub
   List<DrawingPoint> scaledPoints = [];
   for (var cur in points) {
     final Offset scaledP = Offset(xBase + cur.location.dx * fScale, yBase + (cur.location.dy - statusBar) * fScale);
-    scaledPoints.add(DrawingPoint(location: scaledP, type: cur.type, paint: cur.paint));
+    scaledPoints.add(DrawingPoint(location: scaledP, type: cur.type, paint: cur.paint, strokeWidth: cur.strokeWidth));
   }
   return scaledPoints;
 }
@@ -84,7 +84,7 @@ List<DrawingPoint> getSmoothPoints(List<DrawingPoint> pointsWithColors) {
       smoothPoints.add(downPoint);
       final double prevX = pointsWithColors[i - 1].location.dx;
       final double nextY = pointsWithColors[i + 2].location.dy;
-      smoothPoints.add(DrawingPoint(location: Offset(prevX, nextY), type: PointType.regular, paint: Paint()));
+      smoothPoints.add(DrawingPoint(location: Offset(prevX, nextY), type: PointType.regular, paint: Paint(), strokeWidth: cur.strokeWidth));
       i++;
     } else {
       smoothPoints.add(cur);
@@ -138,7 +138,7 @@ List<DrawingPoint> localBresenham(int x0, int y0, int x1, int y1) {
   var sy = (y0 < y1) ? 1 : -1;
   var err = dx - dy;
   while (true) {
-    bresenhamPoints.add(DrawingPoint(location: Offset(x0.toDouble(), y0.toDouble()), type: PointType.regular, paint: Paint()));
+    bresenhamPoints.add(DrawingPoint(location: Offset(x0.toDouble(), y0.toDouble()), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
     if ((x0 == x1) && (y0 == y1)) {
       break;
     }

--- a/lib/brush_handler.dart
+++ b/lib/brush_handler.dart
@@ -42,7 +42,7 @@ void addColor(List<DrawingPoint> points, Color color) {
   else if (color.red == 255 && color.green == 255 && color.blue == 255) {
     colorOffset = whiteOffset;
   }
-  points.add(DrawingPoint(location: colorOffset, type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: colorOffset, type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
   sweepBrushInCup(points);
   sweepBrushInCup(points);
   points.add(upPoint);
@@ -52,38 +52,38 @@ void addColor(List<DrawingPoint> points, Color color) {
 void addWater(List<DrawingPoint> points) {
   points.add(upPoint);
   points.add(downPoint);
-  points.add(DrawingPoint(location: waterOffset, type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: waterOffset, type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
   sweepBrushInCup(points);
 }
 
 void sweepBrushInCup(List<DrawingPoint> points) {
   final double lastX = points.last.location.dx;
   final double lastY = points.last.location.dy;
-  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY - distInCup), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY - distInCup), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY - distInCup), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY - distInCup), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX + distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX - distInCup, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: Offset(lastX            , lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
 }
 
 void cleanBrush(List<DrawingPoint> points) {
   points.add(upPoint);
   points.add(downPoint);
-  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
   final double lastX = points.last.location.dx;
   final double lastY = points.last.location.dy;
-  points.add(DrawingPoint(location: Offset(lastX - distOfCleaner, lastY), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: Offset(lastX - distOfCleaner, lastY), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: cleanerOffset, type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
 }
 
 bool isSameColor(Color first, MaterialColor second) {

--- a/lib/draw_screen.dart
+++ b/lib/draw_screen.dart
@@ -18,7 +18,7 @@ class DrawState extends State<DrawerScreen> {
   List<DrawingPoint> points  = [];
   Color selectedColor        = Colors.red;
   bool displayMenu           = false;
-  double strokeWidth         = 5.1257142857142854;
+  double strokeWidth         = defaultwidth;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -54,7 +54,8 @@ class DrawState extends State<DrawerScreen> {
                   ..strokeCap = StrokeCap.round
                   ..isAntiAlias = true
                   ..color = selectedColor.withOpacity(opacity)
-                  ..strokeWidth = strokeWidth));
+                  ..strokeWidth = strokeWidth,
+                strokeWidth: strokeWidth));
           });
         },
         onPanStart: (details) {
@@ -67,7 +68,8 @@ class DrawState extends State<DrawerScreen> {
                   ..strokeCap = StrokeCap.round
                   ..isAntiAlias = true
                   ..color = selectedColor.withOpacity(opacity)
-                  ..strokeWidth = strokeWidth));
+                  ..strokeWidth = strokeWidth,
+                strokeWidth: strokeWidth));
           });
         },
         onPanEnd: (details) {
@@ -173,9 +175,9 @@ class DrawState extends State<DrawerScreen> {
 
   List<Widget> getWidthCircleList() {
     return [
-      createWidthCircle(3, 16, 16), 
-      createWidthCircle(8, 20, 20), 
-      createWidthCircle(13, 24, 24)
+      createWidthCircle(defaultwidth, 16, 16), 
+      createWidthCircle(mediumWidth, 20, 20), 
+      createWidthCircle(thickWidth, 24, 24)
     ];
   }
 
@@ -252,7 +254,7 @@ class DrawState extends State<DrawerScreen> {
 
   void restartHandler() async {
     selectedColor = Colors.red;
-    strokeWidth   = 5.1257142857142854;
+    strokeWidth   = defaultwidth;
     selectedMenu  = MenuSelection.strokeWidth;
     displayMenu   = false;
     points.clear();

--- a/lib/robot_test.dart
+++ b/lib/robot_test.dart
@@ -20,11 +20,11 @@ void squareTest() async {
   List<DrawingPoint> points = [];
   addColor(points, Colors.red);
   points.add(downPoint);
-  points.add(DrawingPoint(location: const Offset(100, 10) , type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: const Offset(100, 100), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: const Offset(10 , 100), type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: const Offset(10 , 10) , type: PointType.regular, paint: Paint()));
-  points.add(DrawingPoint(location: const Offset(100, 10) , type: PointType.regular, paint: Paint()));
+  points.add(DrawingPoint(location: const Offset(100, 10) , type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: const Offset(100, 100), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: const Offset(10 , 100), type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: const Offset(10 , 10) , type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
+  points.add(DrawingPoint(location: const Offset(100, 10) , type: PointType.regular, paint: Paint(), strokeWidth: defaultwidth));
   await uploadTest(points);
 }
 


### PR DESCRIPTION
Took the 3 different width stats from the app to the bresenham points stage.
Only applies to points made by user (so, not moves inside the cup for example).

To make use of it in the robot, go to getRobotMoves(), in bresenham_algo.dart:171.
There is code there that identifies the specific width a servodown will go to.
Just replace the robotmove you want to change with a new enum.